### PR TITLE
removed auto and server from config (deprecated)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,1 @@
-auto: true
-server: true
 markdown: rdiscount


### PR DESCRIPTION
Warnings appeared when trying to run "jekyll --server", now the new syntax is "jekyll serve", maybe can update the wiki.

auto and server are not required I think.

Signed-off-by: tanji nicholastanjerome@gmail.com
